### PR TITLE
feat: Create and Validate OTP Input

### DIFF
--- a/src/app/_components/form/OTPInput.tsx
+++ b/src/app/_components/form/OTPInput.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from "react"
+
+type Props = {
+  value: number | undefined
+  onChange: (value: number | undefined) => void
+  maxLength: number
+  label: string
+  placeholder?: string
+  error?: boolean
+} & React.InputHTMLAttributes<HTMLInputElement>
+
+export default function OTPInput({
+  value,
+  onChange,
+  maxLength,
+  label,
+  placeholder,
+  error,
+  ...props
+}: Props) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const input = e.target.value.replace(/\D/g, '') // remove non-digits
+    if (input.length > maxLength) return
+    const parsed = parseInt(input, 10)
+    onChange(isNaN(parsed) ? undefined : parsed)
+  }
+
+  const errorText = useMemo(() => {
+    const valueStr = value?.toString()
+    if (valueStr && valueStr.length !== maxLength) return `OTP must be ${maxLength} digits`;
+    return '-'
+  }, [error])
+
+  return (
+    <label className="flex flex-col gap-2 text-base text-black">
+      <span>{label}</span>
+      <input
+        {...props}
+        type="text"
+        inputMode="numeric"
+        pattern="\d*"
+        value={typeof value === 'number' ? value.toString() : ''}
+        onChange={handleChange}
+        maxLength={maxLength}
+        placeholder={placeholder || 'Enter OTP'}
+        required
+        className={`border px-6 py-5 font-semibold rounded w-full ${error && 'border-red-500'}
+        focus:outline-none focus:ring-2 focus:ring-black ${error && 'focus:ring-red-500'}
+        ${props.className ?? ''}`}
+      />
+      <span className={`text-red-500 opacity-0 transition-opacity duration-300 ${error && 'opacity-100'}`}>
+        {errorText}
+      </span>
+    </label>
+  )
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useState } from 'react'
+import OTPInput from '../_components/form/OTPInput'
+
+function Register() {
+  const [otp, setOtp] = useState<number | undefined>(undefined)
+  const [error, setError] = useState(false)
+  const otpLength = 6
+
+  const handleChange = (value: number | undefined) => {
+    setOtp(value)
+    setError(false)
+  }
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    // check otp length
+    if (otp?.toString().length !== otpLength) {
+      setError(true)
+      return
+    }
+  }
+  
+  return (
+    <div className='flex items-center justify-center w-full h-svh'>
+      <form onSubmit={handleSubmit} className='flex flex-col gap-4 w-96'>
+        <OTPInput
+          value={otp}
+          onChange={(value) => handleChange(value as number | undefined)}
+          maxLength={otpLength}
+          label="OTP"
+          placeholder="Enter OTP"
+          error={error}
+        />
+        <button className='bg-[#3B82F6] text-white p-4 rounded-md'>Proceed</button>
+      </form>
+    </div>
+  )
+}
+
+export default Register


### PR DESCRIPTION
## Closes issue: #19

## Description
Introduce an OTP input component with validation and integrate it into a registration form, ensuring proper handling of user input and error states.

## implementation proofs
<img width="1502" alt="Screenshot 2025-05-04 at 13 41 45" src="https://github.com/user-attachments/assets/800de8e8-4a45-40d7-9633-9691bdabbe06" />
<img width="1502" alt="Screenshot 2025-05-04 at 13 42 03" src="https://github.com/user-attachments/assets/1c004117-2538-45f9-8117-a232939b564d" />
<img width="1502" alt="Screenshot 2025-05-04 at 13 42 35" src="https://github.com/user-attachments/assets/d17462da-600b-497f-adf5-d482200a5987" />
