### PR TITLE
feat: add Apibara dispute webhook handlers and schema update

### DIFF
--- a/src/app/api/webhooks/apibara/disputeFlagged/route.ts
+++ b/src/app/api/webhooks/apibara/disputeFlagged/route.ts
@@ -1,0 +1,47 @@
+
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/server/db/index"
+import { disputes } from "@/server/db/schema"
+import { eq } from "drizzle-orm"
+import crypto from "crypto"
+
+const WEBHOOK_SECRET = process.env.APIBARA_WEBHOOK_SECRET!
+
+export async function POST(req: NextRequest) {
+  const signature = req.headers.get("x-signature") || ""
+  const rawBody = await req.text()
+
+  const isValid = verifySignature(rawBody, signature)
+  if (!isValid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+  }
+
+  try {
+    const body = JSON.parse(rawBody)
+    const { taskId, completer, txHash } = body
+
+    if (!taskId || !completer || !txHash) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+    }
+
+    await db
+      .update(disputes)
+      .set({
+        status: "DISPUTED",
+        resolveTxHash: txHash,
+        updatedAt: new Date(),
+      })
+      .where(eq(disputes.disputeId, taskId))
+
+    return NextResponse.json({ success: true }, { status: 200 })
+  } catch (err) {
+    console.error("Webhook error:", err)
+    return NextResponse.json({ error: "Server error" }, { status: 500 })
+  }
+}
+
+function verifySignature(rawBody: string, signature: string): boolean {
+  const hmac = crypto.createHmac("sha256", WEBHOOK_SECRET)
+  const digest = hmac.update(rawBody).digest("hex")
+  return signature === digest
+}

--- a/src/app/api/webhooks/apibara/disputeResolved/route.ts
+++ b/src/app/api/webhooks/apibara/disputeResolved/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/server/db";
+import { disputes } from "@/server/db/schema";
+import { eq } from "drizzle-orm";
+import crypto from "crypto";
+
+const WEBHOOK_SECRET = process.env.APIBARA_WEBHOOK_SECRET!;
+
+export async function POST(req: NextRequest) {
+  const signature = req.headers.get("x-signature") || "";
+  const rawBody = await req.text();
+
+  if (!verifySignature(rawBody, signature)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  try {
+    const body = JSON.parse(rawBody);
+    const { taskId, completer, txHash, resolutionOutcome } = body;
+
+    if (!taskId || !completer || !txHash || !resolutionOutcome) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    }
+
+    type DisputeStatus = "DISPUTED" | "OPEN" | "RESOLVED_APPROVE" | "RESOLVED_REJECT";
+
+    let status: DisputeStatus;
+
+    switch (resolutionOutcome.toLowerCase()) {
+      case "approve":
+      case "approved":
+        status = "RESOLVED_APPROVE";
+        break;
+      case "reject":
+      case "rejected":
+        status = "RESOLVED_REJECT";
+        break;
+      default:
+        return NextResponse.json({ error: "Invalid resolutionOutcome" }, { status: 400 });
+    }
+
+    await db
+      .update(disputes)
+      .set({
+        resolveTxHash: txHash,
+        updatedAt: new Date(),
+        status: resolutionOutcome ===  "approve" ? "RESOLVED_APPROVE" : "RESOLVED_REJECT",
+      })
+      .where(eq(disputes.disputeId, taskId));
+
+    // Optional: Update related submissions status here if needed
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error("disputeResolved webhook error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}
+
+function verifySignature(rawBody: string, signature: string): boolean {
+  const hmac = crypto.createHmac("sha256", WEBHOOK_SECRET);
+  const digest = hmac.update(rawBody).digest("hex");
+  return signature === digest;
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -35,6 +35,7 @@ const submissionStatusEnum = pgEnum('submission_status', [
 ]);
 const disputeStatusEnum = pgEnum('dispute_status', [
   'OPEN',
+  'DISPUTED',
   'RESOLVED_APPROVE',
   'RESOLVED_REJECT',
 ]);


### PR DESCRIPTION
This PR adds webhook handlers for Apibara events related to dispute lifecycle management.

Added /api/webhooks/apibara/disputeFlagged
- Verifies signature
- Parses DisputeFlagged payload
- Updates `disputes` table with status = 'DISPUTED' and tx hash

Added /api/webhooks/apibara/disputeResolved
- Verifies signature
- Parses DisputeResolved payload
- Updates `disputes` table with final resolution status ('RESOLVED_APPROVE' or 'RESOLVED_REJECT') and tx hash


- Updated `schema.ts` to ensure correct DB updates
.

Closes #76 
