### PR TITLE
Feat/implement update task method

### DIFF
--- a/contracts/starknet/src/core/opentask.cairo
+++ b/contracts/starknet/src/core/opentask.cairo
@@ -524,13 +524,9 @@ pub mod OpenTask {
             let caller = get_caller_address();
             assert(task.creator == caller, 'Only creator can update task');
 
-            //Verify task not completed or cancelled
+            //Verify task is active
             assert(task.status == TaskStatus::Active, 'Task is not active');
-
-            //Verify token addresss matches existing
             assert(task.token_address ==token_address, 'Token mismatch');
-            
-            // Validation: Cannot reduce completions below completed count
             assert(required_completions >= task.completed_count, 'Cannot reduce below completed');
             
             //Handle funding/refund logic

--- a/contracts/starknet/src/core/opentask.cairo
+++ b/contracts/starknet/src/core/opentask.cairo
@@ -516,7 +516,66 @@ pub mod OpenTask {
             reward_per_completion: u256,
             required_completions: u32,
         ) -> bool {
-            // TODO: Implement update task logic
+             //Validation: check task exists
+           let mut task = self.tasks.entry(task_id).read();
+            assert(task.creator.is_non_zero(), 'Task does not exit');
+
+            //Authorization: only the task creator can update
+            let caller = get_caller_address();
+            assert(task.creator == caller, 'Only creator can update task');
+
+            //Verify task not completed or cancelled
+            assert(task.status == TaskStatus::Active, 'Task is not active');
+
+            //Verify token addresss matches existing
+            assert(task.token_address ==token_address, 'Token mismatch');
+            
+            // Validation: Cannot reduce completions below completed count
+            assert(required_completions >= task.completed_count, 'Cannot reduce below completed');
+            
+            //Handle funding/refund logic
+            let old_total_required = task.reward_per_completion * task.required_completions.into();
+            let new_total_required = reward_per_completion * required_completions.into();
+            
+            if new_total_required > old_total_required {
+                // Need additional funding
+                let additional  = new_total_required - old_total_required;
+                
+                let contract_address = starknet::get_contract_address();
+                let token = IERC20Dispatcher { contract_address: token_address };
+
+                let allowance = token.allowance(caller, contract_address);
+                assert(allowance >= additional, 'insufficient allowance');
+                
+                let transfer_success= token.transfer_from( caller, contract_address, additional );
+                assert(transfer_success, 'Additional funding failed');
+
+                task.total_funded_amount += additional;
+                }else if new_total_required < old_total_required {
+                // Refund excess funding
+                let refund = old_total_required - new_total_required;
+
+                let token = IERC20Dispatcher { contract_address: token_address };
+
+                let refund_success = token.transfer( caller, refund );
+                assert(refund_success, 'Refund transfer failed');
+
+                task.total_funded_amount -= refund;
+                }
+
+                //Storage updates: apply new parameters
+                let updated_task = TaskDetails {
+                creator: task.creator,
+                token_address: task.token_address,
+                description: description,
+                reward_per_completion: reward_per_completion,
+                required_completions: required_completions,
+                completed_count: task.completed_count,
+                total_funded_amount: new_total_required, 
+                status: task.status,
+    };
+
+                self.tasks.write(task_id, updated_task);
 
             // Emit TaskUpdated event
             self

--- a/contracts/starknet/src/types/task.cairo
+++ b/contracts/starknet/src/types/task.cairo
@@ -45,3 +45,14 @@ pub struct DisputeInfo {
     // Whether the dispute has been resolved
     pub resolved: bool,
 }
+
+/// Structure used for updating task details
+#[derive(Copy, Drop, Serde, PartialEq, starknet::Store)]
+pub struct TaskUpdate {
+    pub task_id: felt252,
+    pub creator: ContractAddress,
+    pub old_required_completions: u32,
+    pub new_required_completions: u32,
+    pub old_reward_per_completion: u256,
+    pub new_reward_per_completion: u256,
+}


### PR DESCRIPTION
This PR introduces the update_task functionality, allowing task creators to update task parameters (description, reward per completion, required completions) before a task is completed or cancelled.

Changes include:

-Validation to ensure the task exists and the caller is the task creator.

-Checks to prevent reducing required completions below the already completed count.

-Logic for handling additional funding or refunds if the reward per completion changes.

-Updates to TaskDetails storage.

-Emission of TaskUpdated event to signal the task update.

this pr closses issue #263 