### PR TITLE
feat: implement create_and_fund_task function in OpenTask contract

### DIFF
--- a/contracts/starknet/src/core/opentask.cairo
+++ b/contracts/starknet/src/core/opentask.cairo
@@ -387,6 +387,77 @@ pub mod OpenTask {
             true
         }
 
+        fn create_and_fund_task(
+            ref self: ContractState,
+            task_id: felt252,
+            creator: ContractAddress,
+            token_address: ContractAddress,
+            description: felt252,
+            reward_per_completion: u256,
+            required_completions: u32,
+        ) -> bool {
+            let caller = get_caller_address();
+            assert(caller == creator, 'NOT_CREATOR');
+
+            let existing_task = self.tasks.entry(task_id).read();
+            assert(existing_task.creator.is_zero(), 'TASK_ALREADY_EXISTS');
+
+            assert(reward_per_completion > 0, 'INVALID_REWARD_AMOUNT');
+
+            assert(required_completions > 0, 'INVALID_COMPLETION_COUNT');
+
+            let total_amount = reward_per_completion
+                * required_completions.try_into().expect('failed to convert');
+
+            let contract_address = starknet::get_contract_address();
+            let token = IERC20Dispatcher { contract_address: token_address };
+
+            let balance = token.balance_of(caller);
+            assert(balance > total_amount, 'INSUFFICIENT BALANCE');
+
+            let allowance = token.allowance(caller, contract_address);
+            assert(allowance >= total_amount, 'INSUFFICIENT_ALLOWANCE');
+
+            let transfer_success = token.transfer_from(caller, contract_address, total_amount);
+            assert(transfer_success, 'TRANSFER_FAILED');
+
+            let details = TaskDetails {
+                creator: creator,
+                token_address: token_address,
+                description: description,
+                reward_per_completion: reward_per_completion,
+                total_funded_amount: total_amount,
+                required_completions: required_completions,
+                completed_count: 0_u32,
+                status: TaskStatus::Active,
+            };
+
+            self.tasks.write(task_id, details);
+
+            self
+                .emit(
+                    TaskCreated {
+                        task_id: task_id,
+                        creator: creator,
+                        token: token_address,
+                        reward_per_completion: reward_per_completion,
+                        required_completions: required_completions,
+                    },
+                );
+
+            self
+                .emit(
+                    TaskFunded {
+                        task_id: task_id,
+                        funder: caller,
+                        amount: total_amount,
+                        token: token_address,
+                    },
+                );
+
+            true
+        }
+
         fn dispute_task(ref self: ContractState, task_id: felt252, submission_id: felt252) -> bool {
             let caller = get_caller_address();
 

--- a/contracts/starknet/src/interfaces/Iopentask.cairo
+++ b/contracts/starknet/src/interfaces/Iopentask.cairo
@@ -65,6 +65,22 @@ pub trait IOpenTask<TContractState> {
         ref self: TContractState, task_id: felt252, token_address: ContractAddress, amount: u256,
     ) -> bool;
 
+    /// Create and fund a task in a single flow.
+    ///
+    /// create and fund a task in a single flow.
+    /// - Transfers/escrows total amount equivalent to `reward_per_completion *
+    /// required_completions` (plus fees off-chain if applicable).
+    /// - Emits: TaskCreated, TaskFunded(task_id, amount)
+    fn create_and_fund_task(
+        ref self: TContractState,
+        task_id: felt252,
+        creator: ContractAddress,
+        token_address: ContractAddress,
+        description: felt252,
+        reward_per_completion: u256,
+        required_completions: u32,
+    ) -> bool;
+
     /// Get full task details from on-chain storage.
     ///
     /// Mirrors backend `task.getTaskById` enriched with on-chain funding and status.

--- a/contracts/starknet/src/interfaces/Iopentask.cairo
+++ b/contracts/starknet/src/interfaces/Iopentask.cairo
@@ -69,7 +69,7 @@ pub trait IOpenTask<TContractState> {
     ///
     /// create and fund a task in a single flow.
     /// - Transfers/escrows total amount equivalent to `reward_per_completion *
-    /// required_completions` (plus fees off-chain if applicable).
+    /// required_completions`.
     /// - Emits: TaskCreated, TaskFunded(task_id, amount)
     fn create_and_fund_task(
         ref self: TContractState,


### PR DESCRIPTION
## Description

This PR implements the core `create_and_fund_task` function in the OpenTask contract, enabling users to efficiently create and fund a task in a single transaction. This enhancement streamlines the workflow for task creators, ensures atomicity between task creation and funding, and improves the overall developer and user experience. The implementation adheres to robust validation, secure token handling, and event-driven transparency.

## 🔗 Related Issue

Closes #262 

## Type of Change

New feature (non-breaking change which adds functionality)  
Refactoring (no functional changes, but improves workflow)  
Test addition or update

##  Key Features & Implementation Details

### 1. Validation
- Ensures only the creator can call `create_and_fund_task`.
- Checks that the provided `task_id` does not already exist in storage.
- Validates that `reward_per_completion > 0` and `required_completions > 0`.

### 2. Token Transfer & Funding
- Calculates the total funding required: `reward_per_completion * required_completions`.
- Integrates with the ERC20 interface to perform a `transferFrom` from the creator to the contract.
- Handles transfer failures gracefully, reverting if the transfer fails.

### 3. Storage Updates
- Creates a new `TaskDetails` entry with status set to `Active`.
- Records the `total_funded_amount` for the task.
- Stores the new task in the contract's `tasks` mapping.

### 4. Event Emission
- Emits `TaskCreated` and `TaskFunded` events for full transparency and off-chain tracking.

### 5. Error Handling
- Comprehensive checks for all edge cases, including duplicate IDs and insufficient funds.
- Reverts on any failure to ensure atomicity.

##  Summary

This PR brings atomic creation and funding to OpenTask, reduces friction for task creators, and ensures robust, secure handling of user funds and task lifecycle.
