### PR TITLE
Header UI Enhancements + OTP Resend Feature

### DIFF
--- a/src/_components/dashboard_components/sidebar.tsx
+++ b/src/_components/dashboard_components/sidebar.tsx
@@ -4,6 +4,7 @@ import { useAtom } from 'jotai';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { authClient } from '~/hooks/authClient';
 import { sidebarAtom } from '~/hooks/sidebarAtom';
 import { routes } from '~/lib/route';
 

--- a/src/_components/landing_page/hero.tsx
+++ b/src/_components/landing_page/hero.tsx
@@ -4,6 +4,8 @@ import { easeOut, motion } from 'framer-motion';
 import Image from 'next/image';
 import { containerVariants } from '~/lib/animations';
 import GetStarted from '../layout/GetStarted';
+import Link from 'next/link';
+import { api } from '~/hooks/queryClient';
 
 const imageVariants: Variants = {
   hidden: { opacity: 0, y: 30 },
@@ -18,6 +20,8 @@ const imageVariants: Variants = {
 };
 
 function HeroPage() {
+  const user = api.auth.getSessionStatus.useQuery();
+  const session = user.data?.session;
   return (
     <motion.section
       variants={containerVariants}
@@ -47,18 +51,31 @@ function HeroPage() {
         Complete simple tasks, earn digital rewards, and learn about crypto at
         your own pace - no wallet or technical knowledge required
       </div>
-      <div className="items-cener mt-8 flex flex-row gap-6">
+      <div className="mt-8 flex flex-row items-center gap-6">
         <button className="rounded-[4px] bg-[#FAFAFA] px-[20px] py-[8px] text-base font-semibold text-[#3B82F6] lg:px-[40px] lg:py-[16px]">
           Learn More
         </button>
 
-        <GetStarted
-          component={
-            <button className="rounded-[4px] bg-[#3B82F6] px-[20px] py-[8px] text-base font-semibold text-white lg:px-[40px] lg:py-[16px]">
-              Register
-            </button>
-          }
-        />
+        {session ? (
+          // logged in
+          <li>
+            <Link
+              className="rounded-lg bg-primary px-6 py-2.5 font-medium capitalize text-white"
+              href={`${user.data?.user?.role.toLowerCase()}/home`}
+            >
+              view dashboard
+            </Link>
+          </li>
+        ) : (
+          // not logged in
+          <GetStarted
+            component={
+              <button className="rounded bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700">
+                Register
+              </button>
+            }
+          />
+        )}
       </div>
 
       <motion.div

--- a/src/_components/layout/navbar.tsx
+++ b/src/_components/layout/navbar.tsx
@@ -7,11 +7,15 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { sidebarAtom } from '~/hooks/sidebarAtom';
 import GetStarted from './GetStarted';
+import { api } from '~/hooks/queryClient';
+import Button from '../ui/button';
 const sections = ['home', 'features', 'contact us'];
 
 export function Navbar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeSection, setActiveSection] = useState<string>('home');
+  const user = api.auth.getSessionStatus.useQuery();
+  const session = user.data?.session;
 
   useEffect(() => {
     const handleScroll = () => {
@@ -49,12 +53,6 @@ export function Navbar() {
 
         {/* Desktop Nav */}
         <ul className="hidden items-center gap-6 md:flex">
-          {/* <button
-            className=""
-            onClick={() => setIsSidebarOpen((prev) => !prev)}
-          >
-            <PanelLeft className="h-[20px] w-[20px] text-black" />
-          </button> */}
           {sections.map((section) => (
             <li key={section}>
               <a
@@ -68,15 +66,28 @@ export function Navbar() {
               </a>
             </li>
           ))}
-          <li>
-            <GetStarted
-              component={
-                <button className="rounded bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700">
-                  Register
-                </button>
-              }
-            />
-          </li>
+          {session ? (
+            // logged in
+            <li>
+              <Link
+                className="rounded-lg bg-primary px-6 py-2.5 font-medium capitalize text-white"
+                href={`${user.data?.user?.role.toLowerCase()}/home`}
+              >
+                view dashboard
+              </Link>
+            </li>
+          ) : (
+            // not logged in
+            <li>
+              <GetStarted
+                component={
+                  <button className="rounded bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700">
+                    Register
+                  </button>
+                }
+              />
+            </li>
+          )}
         </ul>
 
         {/* Hamburger */}

--- a/src/_components/layout/navbar.tsx
+++ b/src/_components/layout/navbar.tsx
@@ -66,7 +66,7 @@ export function Navbar() {
               </a>
             </li>
           ))}
-          {session ? (
+          {user.isLoading ? null : session ? (
             // logged in
             <li>
               <Link
@@ -78,15 +78,25 @@ export function Navbar() {
             </li>
           ) : (
             // not logged in
-            <li>
-              <GetStarted
-                component={
-                  <button className="rounded bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700">
-                    Register
-                  </button>
-                }
-              />
-            </li>
+            <>
+              <li>
+                <GetStarted
+                  component={
+                    <button className="rounded bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700">
+                      Register
+                    </button>
+                  }
+                />
+              </li>
+              <li>
+                <Link
+                  className="bg-primary px-6 py-2.5 font-medium capitalize text-white"
+                  href={`/login`}
+                >
+                  login
+                </Link>
+              </li>
+            </>
           )}
         </ul>
 

--- a/src/app/(auth)/otp/page.tsx
+++ b/src/app/(auth)/otp/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -22,6 +22,7 @@ function Otp() {
   const searchParams = useSearchParams();
   const resetEmail = searchParams.get('reset_email');
   const email = searchParams.get('email')!;
+  const [isSendingOtp, setIsSendingOtp] = useState(false);
   const {
     // register,
     handleSubmit,
@@ -42,6 +43,48 @@ function Otp() {
 
   const handleOtpInputChange = (value: string) => {
     setValue('otp', value);
+  };
+
+  const [timer, setTimer] = useState(60); // 60 seconds (1 minute)
+
+  useEffect(() => {
+    if (timer <= 0) return;
+
+    const interval = setInterval(() => {
+      setTimer((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [timer]);
+
+  // Format function: converts seconds -> mm:ss
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  };
+
+  const handleResendOtp = async () => {
+    setIsSendingOtp(true);
+    try {
+      const newOtp = await authClient.emailOtp.sendVerificationOtp({
+        email: email,
+        type: 'email-verification',
+      });
+
+      if (!newOtp.data?.success) {
+        throw new Error('error while trying to send otp');
+        toast.error('Email not found');
+        return;
+      }
+
+      toast.success('OTP resent successfully!');
+      setTimer(60);
+    } catch (err: unknown) {
+      toast.error('Failed to resend OTP');
+    } finally {
+      setIsSendingOtp(false);
+    }
   };
 
   const onSubmit = async (data: OtpFormData) => {
@@ -102,11 +145,6 @@ function Otp() {
     }
   };
 
-  // Add console logs for debugging
-  console.log('Current OTP value:', otpValue);
-  console.log('Email from params:', email);
-  console.log('Reset email from params:', resetEmail);
-
   return (
     <div className="flex h-svh w-full items-center justify-center">
       <AuthWrapper
@@ -135,6 +173,19 @@ function Otp() {
             disabled={isSubmitting || otpValue.length !== 6}
           >
             {isSubmitting ? 'Verifying...' : 'Proceed'}
+          </button>
+
+          <button
+            type="button"
+            onClick={handleResendOtp}
+            disabled={timer > 0}
+            className="rounded-md p-3 text-primary disabled:cursor-not-allowed disabled:text-gray-400"
+          >
+            {isSendingOtp
+              ? 'sending...'
+              : timer > 0
+                ? `Resend OTP in ${formatTime(timer)}`
+                : 'Resend OTP'}
           </button>
         </form>
       </AuthWrapper>

--- a/src/app/[accessType]/learning/type/[id]/LearningDetails.tsx
+++ b/src/app/[accessType]/learning/type/[id]/LearningDetails.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import Image from 'next/image';
+import Button from '~/_components/ui/button';
+import { useState } from 'react';
+
+interface LearningItem {
+  id: string | number;
+  title: string;
+  image: string;
+  duration: string;
+  rewardInEth: number;
+  rewardInUsd?: number;
+  modules?: string; // For courses
+  type: 'course' | 'tutorial';
+  video?: string; // Optional video property
+  description?: string;
+}
+
+export default function LearningDetail({ course }: { course?: LearningItem }) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const router = useRouter();
+
+  // when course page is empty
+  if (!course) {
+    return (
+      <div className="mx-auto py-8">
+        <div className="text-center">
+          <h1 className="mb-4 text-2xl font-bold">Course Not Found</h1>
+          <p className="mb-6 text-[#414141]">
+            The task you&apos;re looking for doesn&apos;t exist or has been
+            removed.
+          </p>
+          <button
+            onClick={() => router.back()}
+            className="mx-auto flex items-center gap-2 text-blue-500 hover:text-blue-600"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Go Back
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto">
+      {/* Task Content */}
+      <div className="rounded-lg">
+        <h1 className="pb-0 text-xl font-bold capitalize leading-[100%] md:max-w-[980px] md:text-[40px]">
+          {course.title}
+        </h1>
+
+        <div className="space-y-4 md:max-w-[1058px]">
+          <div className="mt-6 h-[200px] w-full md:h-[500px]">
+            {!isPlaying ? (
+              // Thumbnail with play button
+              <div
+                onClick={() => setIsPlaying(true)}
+                className="group relative h-[200px] w-full cursor-pointer items-center justify-center overflow-hidden rounded-lg hover:bg-black/40 md:h-[500px]"
+              >
+                {/* Background Image */}
+                <Image
+                  src={
+                    course.image ||
+                    (course.type === 'course'
+                      ? '/images/courseImg.png'
+                      : '/images/cryptoImg.png')
+                  }
+                  alt="course banner"
+                  fill
+                  quality={100}
+                  className="object-cover"
+                />
+
+                {/* Play button overlay */}
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <Image
+                    src="/icons/play.svg"
+                    alt="Play"
+                    width={48}
+                    height={48}
+                    className="h-12 w-12"
+                  />
+                </div>
+              </div>
+            ) : course.video ? (
+              <video
+                className="h-[200px] w-full rounded-lg md:h-[500px]"
+                controls
+                autoPlay
+              >
+                <source src={course.video} type="video/mp4" />
+                Your browser does not support the video tag.
+              </video>
+            ) : (
+              <div className="flex h-[200px] w-full items-center justify-center rounded-lg bg-gray-200 md:h-[500px]">
+                <span className="text-gray-500">No video available</span>
+              </div>
+            )}
+          </div>
+
+          <div className="mx-auto flex w-full flex-col space-y-4 py-4 md:max-w-[886px]">
+            <div className="rounded-lg bg-white p-6">
+              <h2 className="mb-3 text-lg font-bold md:text-2xl">Summary</h2>
+              <p className="mb-4 text-sm text-[#414141] md:text-base md:leading-[32px]">
+                {course.description ??
+                  'Lorem ipsum dolor sit amet consectetur. Dolor justo diam amet tincidunt ut nunc. Dictum non fermentum proin sed etiam. Ipsum turpis neque eros quisque aliquet vulputate sed venenatis lectus. Morbi in aliquam interdum pellentesque. Lorem ipsum dolor sit amet consectetur. Dolor justo diam amet tincidunt ut nunc. Dictum non fermentum proin sed etiam. Ipsum turpis neque eros quisque aliquet vulputate sed venenatis lectus. Morbi in aliquam interdum pellentesque.'}
+              </p>
+            </div>
+
+            <div className="rounded-lg bg-white p-6">
+              <h2 className="mb-3 text-lg font-bold md:text-2xl">
+                Reward & Duration
+              </h2>
+
+              <div className="mb-8 flex flex-wrap gap-8">
+                <div className="flex items-center gap-2">
+                  <Image
+                    src="/icons/calendar.svg"
+                    alt="Task icon"
+                    width={60}
+                    height={60}
+                    className="h-[60px] w-[60px]"
+                  />
+                  <div>
+                    <div className="text-sm font-semibold">Duration</div>
+                    <div className="text-base font-bold md:text-xl">
+                      {course.duration}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <Image
+                    src="/icons/diamond.svg"
+                    alt="course icon"
+                    width={60}
+                    height={60}
+                    className="h-[60px] w-[60px]"
+                  />
+                  <div>
+                    <div className="text-sm font-semibold">REWARD</div>
+                    <div className="text-base font-bold md:text-xl">
+                      {course.rewardInEth} ETH
+                      {course.rewardInUsd && (
+                        <span className="text-base text-blue-500">
+                          &asymp; ${course.rewardInUsd.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Modules – show only for Course */}
+            {course.type === 'course' && course.modules && (
+              <div className="rounded-lg bg-white p-6">
+                <h2 className="mb-3 text-lg font-bold md:text-2xl">Modules</h2>
+
+                <div className="">
+                  <div className="flex w-full flex-col justify-between gap-4 md:flex-row">
+                    <div className="flex w-full items-center justify-between rounded-md bg-main p-4 text-sm font-semibold md:text-base">
+                      <h1 className="text medium">
+                        Module 1: Introduction to Micro Tasks
+                      </h1>
+
+                      <Image
+                        src="/icons/success.svg"
+                        alt="Task icon"
+                        width={20}
+                        height={20}
+                        className="h-[20px] w-[20px]"
+                      />
+                    </div>
+
+                    <div className="flex w-full items-center justify-between rounded-md bg-main p-4 text-sm font-semibold md:text-base">
+                      <h1 className="text medium">Module 2: Getting Started</h1>
+
+                      <Image
+                        src="/icons/play.svg"
+                        alt="Task icon"
+                        width={20}
+                        height={20}
+                        className="h-[20px] w-[20px]"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="flex w-full justify-end gap-4 py-5">
+              <Button
+                className="w-full p-3 md:w-[450px]"
+                onClick={() => router.back()}
+              >
+                done
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[accessType]/learning/type/[id]/page.tsx
+++ b/src/app/[accessType]/learning/type/[id]/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import LearningDetail from './LearningDetails';
+import { api } from '~/trpc/react';
+
+export default function LearningDetailPage() {
+  const { id } = useParams();
+  const itemId = Array.isArray(id) ? id[0] : id;
+
+  // Fetch course by ID
+  const { data: courseData, isLoading: courseLoading } =
+    api.learning.getCourseById.useQuery(
+      { courseId: itemId ?? '' },
+      { enabled: !!itemId },
+    );
+
+  // Fetch tutorial by ID
+  const { data: tutorialData, isLoading: tutorialLoading } =
+    api.learning.getTutorialById.useQuery(
+      { tutorialId: itemId ?? '' },
+      { enabled: !!itemId },
+    );
+
+  // Determine which item we found
+  const item = courseData
+    ? {
+        ...courseData,
+        type: 'course' as const,
+        id: courseData.courseId,
+        image: courseData.imageUrl ?? '',
+        rewardInEth: parseFloat(courseData.rewardAmount),
+        modules: courseData.modules?.toString(),
+      }
+    : tutorialData
+      ? {
+          ...tutorialData,
+          type: 'tutorial' as const,
+          id: tutorialData.tutorialId,
+          image: tutorialData.imageUrl ?? '',
+          rewardInEth: parseFloat(tutorialData.rewardAmount),
+        }
+      : undefined;
+
+  if (courseLoading || tutorialLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <LearningDetail course={item} />
+    </>
+  );
+}


### PR DESCRIPTION
**Summary**

This PR introduces two key frontend improvements:

Header Enhancements & UI Cleanup

Added a Login button to the header.

Hide auth-related buttons (Login, Signup) when a user session exists.

OTP Verification Improvements

Added a Resend OTP button to the OTP verification screen.

Implemented cooldown states and proper loading feedback when resending OTP.

**Expected Behavior**
Header

Login button visible only for logged-out users.

Auth buttons hidden when session exists.

OTP Verification

Resend OTP button visible below the input.

Cooldown timer displayed (e.g., Resend in 00:30).

Clicking Resend calls the endpoint and provides feedback.

**screenShoot** 

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/fad14b03-f788-4a20-aeea-ab7a4aa76b0b" />
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/5c8c8d20-3a2c-42db-9776-4b5b3b7a7a91" />

colse #307 


